### PR TITLE
Fix cv.plasso() so coef_min_pl stores Post-Lasso instead of Lasso coefficients

### DIFF
--- a/R/cv.plasso.R
+++ b/R/cv.plasso.R
@@ -139,8 +139,17 @@ cv.plasso = function(x,y,
   
   # Get Lasso coefficients at minimum of Lasso
   coef_min_l = coef_lasso_full[,ind_min_l][which(coef_lasso_full[,ind_min_l] != 0)]
-  # Get Lasso coefficients at minimum of Post-Lasso
-  coef_min_pl = coef_lasso_full[,ind_min_pl][which(coef_lasso_full[,ind_min_pl] != 0)]
+  
+  # Get Lasso coefficients at minimum of Post-Lasso (including zeros)
+  coef_pl_lasso_min = coef_lasso_full[,ind_min_pl]
+  # Add intercept only if it is part of the active set
+  x_pl = x
+  if ("(Intercept)" %in% names_pl) {
+    x_pl = add_intercept(x_pl)
+  }
+  # Get Post-Lasso coefficients at minimum of Post-Lasso
+  coef_min_pl = fit_betas(x_pl,y,w,names_pl,coef_pl_lasso_min)
+  coef_min_pl = coef_min_pl[which(coef_min_pl != 0)]
   
   # Return names and coefficients
   output = list("call"=this.call,


### PR DESCRIPTION
This PR fixes `coef_min_pl` in `cv.plasso()`.

Previously, `coef_min_pl` stored the Lasso coefficients at `ind_min_pl`, even though it is documented as the coefficients for the MSE-optimal Post-Lasso model.

This patch computes `coef_min_pl` via `fit_betas()` using the active set selected at `ind_min_pl`, so that it stores the actual Post-Lasso coefficients.

Intercept handling is kept consistent by only adding an intercept when `"(Intercept)"` is part of the active set.